### PR TITLE
Update project.spec.js

### DIFF
--- a/cypress/integration/project.spec.js
+++ b/cypress/integration/project.spec.js
@@ -393,7 +393,7 @@ describe('Facebook Signup', () => {
               topOptions.push(radio.getBoundingClientRect()[`top`]);
             });
 
-            expect([...new Set(topOptions)][0] > (topLabel + heightLabel)).to.equal(true);
+            expect([...new Set(topOptions)][0] >= (topLabel + heightLabel)).to.equal(true);
           });
         }); 
     });


### PR DESCRIPTION
Foi constatado um erro no requisito 16 no qual não passava no avaliador se não houvesse espaçamento. Isso acontecia porque a verificação era  o radio button ser maior do que a label e não maior igual. 